### PR TITLE
chore: go-demo-6 to 1.0.394

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -7,3 +7,6 @@ dependencies:
   name: exposecontroller
   repository: http://chartmuseum.jenkins-x.io
   version: 2.3.89
+- name: go-demo-6
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 1.0.394


### PR DESCRIPTION
chore: Promote go-demo-6 to version 1.0.394